### PR TITLE
Fix next meal display based on current time

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,17 +1,5 @@
 let date;
 
-const now = () => {
-  const time = date.format("HH:mm:ss");
-
-  if (time < "08:00:00") {
-    return 0;
-  } else if (time < "14:00:00") {
-    return 1;
-  } else {
-    return 2;
-  }
-};
-
 const getMeal = (date) => {
   $(`#app`).append(`<div id="loading" class="lds-dual-ring"></div>`);
   $.ajax({
@@ -58,6 +46,21 @@ const control = (type) => {
     case "tomorrow":
       date.add(1, "day");
       break;
+    case "now":
+      date = moment();
+      const time = date.format("HH:mm:ss");
+
+      if (time >= "19:30:00") {
+        date.add(1, "day");
+        $("#scroll").scrollLeft($("#list #item.breakfast").width() * 0);
+      } else if (time >= "14:00:00") {
+        $("#scroll").scrollLeft($("#list #item.breakfast").width() * 2);
+      } else if (time >= "08:00:00") {
+        $("#scroll").scrollLeft($("#list #item.breakfast").width() * 1);
+      } else {
+        $("#scroll").scrollLeft($("#list #item.breakfast").width() * 0);
+      }
+      break;
     default:
       date = moment(type);
       break;
@@ -68,8 +71,6 @@ const control = (type) => {
 };
 
 const init = () => {
-  control();
-
   let controller = new ScrollMagic.Controller({
     container: "#scroll",
     vertical: false,
@@ -114,7 +115,7 @@ const init = () => {
     )
     .addTo(controller);
 
-  $("#scroll").scrollLeft($("#list #item.breakfast").width() * now());
+  control("now");
 
   $("#control #pre").click(() => control("yesterday"));
   $("#control #next").click(() => control("tomorrow"));


### PR DESCRIPTION
Fixes #2

Update the web page to display the next meal based on the user's current time.

* Remove the `now` function from `js/utils.js`.
* Update the `control` function to handle the "now" case by setting the date based on the current time.
* Add logic to the "now" case to check if the current time is after 19:30 and set the date to the next day and display breakfast.
* Update the `init` function to call the `control` function with the "now" case.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/dimigomeal/web/issues/2?shareId=8cab0beb-5c46-4775-b709-60356a62287f).